### PR TITLE
FIX: Added missing MspDeInitCallback set to weak MspDeInit.

### DIFF
--- a/Src/stm32u5xx_hal_adc.c
+++ b/Src/stm32u5xx_hal_adc.c
@@ -500,6 +500,11 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
       hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit  */
     }
 
+    if (hadc->MspDeInitCallback == NULL)
+    {
+      hadc->MspDeInitCallback = HAL_ADC_MspDeInit;
+    }
+
     /* Init the low level hardware */
     hadc->MspInitCallback(hadc);
 #else


### PR DESCRIPTION
This callback is called from within HAL_ADC "stop" functions and cause calling thread to crash. Effectively, the ADC conversions could not be started after being stopped. Setting them to a weak placeholder function fixes the crash and conversion restarting issue.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32u5xx_hal_driver/blob/main/CONTRIBUTING.md) file.
