### PR TITLE
[HAL][UART] Fix HAL_UART_Receive() blocking on rx overrun when called…

### DIFF
--- a/Src/stm32u5xx_hal_uart.c
+++ b/Src/stm32u5xx_hal_uart.c
@@ -3481,43 +3481,43 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
 
         return HAL_TIMEOUT;
       }
+    }
 
-      if ((READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U) && (Flag != UART_FLAG_TXE) && (Flag != UART_FLAG_TC))
+    if ((READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U) && (Flag != UART_FLAG_TXE) && (Flag != UART_FLAG_TC))
+    {
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) == SET)
       {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) == SET)
-        {
-          /* Clear Overrun Error flag*/
-          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+        /* Clear Overrun Error flag*/
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
 
-          /* Blocking error : transfer is aborted
-          Set the UART state ready to be able to start again the process,
-          Disable Rx Interrupts if ongoing */
-          UART_EndRxTransfer(huart);
+        /* Blocking error : transfer is aborted
+        Set the UART state ready to be able to start again the process,
+        Disable Rx Interrupts if ongoing */
+        UART_EndRxTransfer(huart);
 
-          huart->ErrorCode = HAL_UART_ERROR_ORE;
+        huart->ErrorCode = HAL_UART_ERROR_ORE;
 
-          /* Process Unlocked */
-          __HAL_UNLOCK(huart);
+        /* Process Unlocked */
+        __HAL_UNLOCK(huart);
 
-          return HAL_ERROR;
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RTOF) == SET)
-        {
-          /* Clear Receiver Timeout flag*/
-          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_RTOF);
+        return HAL_ERROR;
+      }
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RTOF) == SET)
+      {
+        /* Clear Receiver Timeout flag*/
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_RTOF);
 
-          /* Blocking error : transfer is aborted
-          Set the UART state ready to be able to start again the process,
-          Disable Rx Interrupts if ongoing */
-          UART_EndRxTransfer(huart);
+        /* Blocking error : transfer is aborted
+        Set the UART state ready to be able to start again the process,
+        Disable Rx Interrupts if ongoing */
+        UART_EndRxTransfer(huart);
 
-          huart->ErrorCode = HAL_UART_ERROR_RTO;
+        huart->ErrorCode = HAL_UART_ERROR_RTO;
 
-          /* Process Unlocked */
-          __HAL_UNLOCK(huart);
+        /* Process Unlocked */
+        __HAL_UNLOCK(huart);
 
-          return HAL_TIMEOUT;
-        }
+        return HAL_TIMEOUT;
       }
     }
   }


### PR DESCRIPTION
… with Timeout = HAL_MAX_DELAY

When called with Timeout = HAL_MAX_DELAY the function HAL_UART_Receive() blocks if rx Overrun Error occurs.
This PR fixes the issue and closes #23 


## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32u5xx_hal_driver/blob/main/CONTRIBUTING.md) file.
